### PR TITLE
feat: implement update checker

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -7,6 +7,7 @@ export {
   red,
   brightGreen,
   gray,
+  yellow,
 } from "https://deno.land/std@0.192.0/fmt/colors.ts";
 export { z } from "https://deno.land/x/zod@v3.22.2/mod.ts";
 export { decompress } from "https://deno.land/x/zip@v1.2.5/mod.ts";

--- a/main.ts
+++ b/main.ts
@@ -2,7 +2,7 @@ import { Command } from "cliffy/command";
 import run from "./src/cmd/run.ts";
 import init from "./src/cmd/init.ts";
 import search from "./src/cmd/search.ts";
-import upgrade from "./src/cmd/upgrade.ts";
+import upgrade, { checkForUpdate } from "./src/cmd/upgrade.ts";
 import listJobs from "./src/cmd/list.ts";
 import generateWorkflow from "./src/cmd/github.ts";
 import generateGitlabCIConfig from "./src/cmd/gitlab.ts";
@@ -39,8 +39,9 @@ export async function main() {
     .arguments("[pipeline:string] [jobs...:string]")
     .option("-r, --reload", "Reload pipeline source cache")
     .option("-*, --* <args:string>", "Pass arguments to pipeline")
-    .action(function (options, pipeline, ...jobs: [string, ...Array<string>]) {
-      run(pipeline || ".", jobs, options);
+    .action(async function (options, pipeline, ...jobs: [string, ...Array<string>]) {
+      await run(pipeline || ".", jobs, options);
+      await checkForUpdate();
     })
     .command("run", "Run a pipeline")
     .arguments("<pipeline:string> [jobs...:string]")

--- a/main.ts
+++ b/main.ts
@@ -39,9 +39,8 @@ export async function main() {
     .arguments("[pipeline:string] [jobs...:string]")
     .option("-r, --reload", "Reload pipeline source cache")
     .option("-*, --* <args:string>", "Pass arguments to pipeline")
-    .action(async function (options, pipeline, ...jobs: [string, ...Array<string>]) {
-      await run(pipeline || ".", jobs, options);
-      await checkForUpdate();
+    .action(function (options, pipeline, ...jobs: [string, ...Array<string>]) {
+      run(pipeline || ".", jobs, options);
     })
     .command("run", "Run a pipeline")
     .arguments("<pipeline:string> [jobs...:string]")
@@ -219,6 +218,10 @@ export async function main() {
     .command("whoami", "Show current logged in user")
     .action(async function () {
       await whoami();
+    })
+    .globalOption("--check-update <checkUpdate:boolean>", "check for update", {default: true})
+    .globalAction(async (options) => {
+        await checkForUpdate(options)
     })
     .parse(Deno.args);
 }

--- a/main.ts
+++ b/main.ts
@@ -220,7 +220,7 @@ export async function main() {
       await whoami();
     })
     .globalOption("--check-update <checkUpdate:boolean>", "check for update", {default: true})
-    .globalAction(async (options) => {
+    .globalAction(async (options: { checkUpdate: boolean }) => {
         await checkForUpdate(options)
     })
     .parse(Deno.args);

--- a/src/cmd/agent.ts
+++ b/src/cmd/agent.ts
@@ -23,7 +23,7 @@ import {
 } from "../utils.ts";
 import { hostname, release, cpus, arch, totalmem, platform } from "node:os";
 import { Agent } from "../types.ts";
-import O from "https://esm.sh/v133/mimic-fn@4.0.0/denonext/mimic-fn.mjs";
+// import O from "https://esm.sh/v133/mimic-fn@4.0.0/denonext/mimic-fn.mjs";
 
 async function startAgent() {
   console.log(`

--- a/src/cmd/upgrade.ts
+++ b/src/cmd/upgrade.ts
@@ -27,7 +27,7 @@ async function upgrade() {
 
 export default upgrade;
 
-export async function checkForUpdate(options) {
+export async function checkForUpdate(options: { checkUpdate: boolean }) {
   const { checkUpdate } = options
   if (!checkUpdate) {
     return

--- a/src/cmd/upgrade.ts
+++ b/src/cmd/upgrade.ts
@@ -27,7 +27,12 @@ async function upgrade() {
 
 export default upgrade;
 
-export async function checkForUpdate() {
+export async function checkForUpdate(options) {
+  const { checkUpdate } = options
+  if (!checkUpdate) {
+    return
+  }
+
   try {
     const result = await fetch("https://api.github.com/repos/fluentci-io/fluentci/releases/latest")
     const releaseInfo = await result.json()

--- a/src/cmd/upgrade.ts
+++ b/src/cmd/upgrade.ts
@@ -1,3 +1,6 @@
+import { VERSION } from "../consts.ts";
+import { yellow, green } from "../../deps.ts";
+
 /**
  * Upgrades FluentCI by installing the latest version from the Deno registry.
  * @returns {Promise<void>}
@@ -23,3 +26,33 @@ async function upgrade() {
 }
 
 export default upgrade;
+
+export async function checkForUpdate() {
+  try {
+    const result = await fetch("https://api.github.com/repos/fluentci-io/fluentci/releases/latest")
+    const releaseInfo = await result.json()
+ 
+   if (versionGreaterThan(releaseInfo.tag_name, VERSION)) {
+      console.log(
+    `${green('A new release of fluentci is available:')} ${VERSION} → ${releaseInfo.tag_name} \nTo upgrade: run fluentci upgrade\n${releaseInfo.url}
+   `)
+    }
+  } catch (e) {
+    console.log(`
+      ${yellow('WARNING: ')} checking for udpate failed ${e}
+    `)
+  }
+}
+
+export const versionGreaterThan = (v1: string, v2: string): boolean => {
+  const numbers1 = v1.replace('v', '').split('.').map(Number)
+  const numbers2 = v2.replace('v', '').split('.').map(Number)
+
+  for (let i = 0; i < 3; i++) {
+    if (numbers1[i] > numbers2[i]) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,6 +1,6 @@
 import { dir } from "../deps.ts";
 
-export const VERSION = "0.10.8";
+export const VERSION = "0.10.7";
 
 export const BASE_URL = "https://api.fluentci.io/v1";
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,6 +1,6 @@
 import { dir } from "../deps.ts";
 
-export const VERSION = "0.10.7";
+export const VERSION = "0.10.8";
 
 export const BASE_URL = "https://api.fluentci.io/v1";
 

--- a/tests/upgrade.test.ts
+++ b/tests/upgrade.test.ts
@@ -1,0 +1,32 @@
+import { assertEquals } from "https://deno.land/std@0.206.0/assert/mod.ts";
+import { versionGreaterThan } from '../src/cmd/upgrade.ts'
+
+Deno.test("semver comparasion", () => {
+    const tests = [
+        {
+            v1: "v0.10.1",
+            v2: "v0.10.2",
+            want: false
+        },
+        {
+            v1: "v0.10.2",
+            v2: "v0.10.1",
+            want: true
+        },
+        {
+            v1: "v2.10.1",
+            v2: "v0.10.1",
+            want: true
+        },
+        {
+            v1: "v0.10.0",
+            v2: "v0.10.0",
+            want: false
+        },
+    ]
+
+    tests.forEach((tt) => {
+        const res = versionGreaterThan(tt.v1, tt.v2)
+        assertEquals(res, tt.want)
+    })
+});


### PR DESCRIPTION
* the update check calls [api.github.com/l ](https://api.github.com/repos/fluentci-io/fluentci/releases/latest) to get the latest release version and compares it with the local version
* ~right now the checker is only run on the default command (please suggest for better strategy)~

<img width="572" alt="Screenshot 2024-01-13 at 19 57 16" src="https://github.com/fluentci-io/fluentci/assets/4066051/aa2b2589-55e4-4925-a17a-816b9b0740f9">

* check update runs by default after each command, the user can disable it by using the global options --check-update=false
